### PR TITLE
Update configuration to make tests runnable

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -71,7 +71,9 @@ module.exports = {
   // ],
 
   // A map from regular expressions to module names that allow to stub out resources with a single module
-  // moduleNameMapper: {},
+  moduleNameMapper: {
+    "^modules/(.*)": "<rootDir>/src/modules/$1",
+  },
 
   // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
   // modulePathIgnorePatterns: [],

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,4 +1,6 @@
 import { configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 
-configure({adapter: new Adapter() });
+configure({ adapter: new Adapter() });
+
+global.navigator = { userAgent: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36' };


### PR DESCRIPTION
This PR makes two configuration changes:

1. Have jest module mapper resolve paths to `src/modules` for custom modules in the project
2. Set a user agent in `global.navigator` to resolve warning messages for Radium: https://github.com/FormidableLabs/radium/tree/master/docs/faq#how-can-i-get-rid-of-useragent-warnings-in-tests