### PR TITLE
Resolve absolute component paths in jest config

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -73,6 +73,7 @@ module.exports = {
   // A map from regular expressions to module names that allow to stub out resources with a single module
   moduleNameMapper: {
     "^modules/(.*)": "<rootDir>/src/modules/$1",
+    "^components/(.*)": "<rootDir>/src/components/$1",
   },
 
   // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader


### PR DESCRIPTION
For reference:
https://jestjs.io/docs/en/webpack

It seems like webpack's resolve configuration won't be picked up by jest, and so we need to map these paths in jest's config file.
https://github.com/vire/jest-vue-preprocessor/issues/25