### PR TITLE
Route to event form

### DIFF
--- a/src/__tests__/Home.test.jsx
+++ b/src/__tests__/Home.test.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import Home from 'components/Home';
+
+describe('Home component tests', () => {
+  it('renders the Home component', () => {
+    const wrapper = shallow(<Home />);
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/__tests__/__snapshots__/Home.test.jsx.snap
+++ b/src/__tests__/__snapshots__/Home.test.jsx.snap
@@ -1,0 +1,200 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Home component tests renders the Home component 1`] = `
+ShallowWrapper {
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <Home />,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "children": <li
+        data-radium={true}
+        style={
+          Object {
+            "listStyle": "none",
+          }
+        }
+      >
+        <Link
+          replace={false}
+          style={
+            Object {
+              ":hover": Object {
+                "textDecoration": "underline",
+              },
+              "textDecoration": "none",
+            }
+          }
+          to="/create"
+        >
+          Create an Event
+        </Link>
+      </li>,
+      "data-radium": true,
+      "style": Object {
+        "font": "20px Helvetica, sans-serif",
+      },
+    },
+    "ref": null,
+    "rendered": Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": <Link
+          replace={false}
+          style={
+            Object {
+              ":hover": Object {
+                "textDecoration": "underline",
+              },
+              "textDecoration": "none",
+            }
+          }
+          to="/create"
+        >
+          Create an Event
+        </Link>,
+        "data-radium": true,
+        "style": Object {
+          "listStyle": "none",
+        },
+      },
+      "ref": null,
+      "rendered": Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "class",
+        "props": Object {
+          "children": "Create an Event",
+          "replace": false,
+          "style": Object {
+            ":hover": Object {
+              "textDecoration": "underline",
+            },
+            "textDecoration": "none",
+          },
+          "to": "/create",
+        },
+        "ref": null,
+        "rendered": "Create an Event",
+        "type": [Function],
+      },
+      "type": "li",
+    },
+    "type": "ul",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": <li
+          data-radium={true}
+          style={
+            Object {
+              "listStyle": "none",
+            }
+          }
+        >
+          <Link
+            replace={false}
+            style={
+              Object {
+                ":hover": Object {
+                  "textDecoration": "underline",
+                },
+                "textDecoration": "none",
+              }
+            }
+            to="/create"
+          >
+            Create an Event
+          </Link>
+        </li>,
+        "data-radium": true,
+        "style": Object {
+          "font": "20px Helvetica, sans-serif",
+        },
+      },
+      "ref": null,
+      "rendered": Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": <Link
+            replace={false}
+            style={
+              Object {
+                ":hover": Object {
+                  "textDecoration": "underline",
+                },
+                "textDecoration": "none",
+              }
+            }
+            to="/create"
+          >
+            Create an Event
+          </Link>,
+          "data-radium": true,
+          "style": Object {
+            "listStyle": "none",
+          },
+        },
+        "ref": null,
+        "rendered": Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {
+            "children": "Create an Event",
+            "replace": false,
+            "style": Object {
+              ":hover": Object {
+                "textDecoration": "underline",
+              },
+              "textDecoration": "none",
+            },
+            "to": "/create",
+          },
+          "ref": null,
+          "rendered": "Create an Event",
+          "type": [Function],
+        },
+        "type": "li",
+      },
+      "type": "ul",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+        "lifecycles": Object {
+          "componentDidUpdate": Object {
+            "onSetState": true,
+          },
+          "getDerivedStateFromProps": true,
+          "getSnapshotBeforeUpdate": true,
+          "setState": Object {
+            "skipsComponentDidUpdateOnNullish": true,
+          },
+        },
+      },
+    },
+    "attachTo": undefined,
+    "hydrateIn": undefined,
+  },
+}
+`;

--- a/src/__tests__/__snapshots__/Home.test.jsx.snap
+++ b/src/__tests__/__snapshots__/Home.test.jsx.snap
@@ -34,7 +34,7 @@ ShallowWrapper {
               "textDecoration": "none",
             }
           }
-          to="/create"
+          to="/new"
         >
           Create an Event
         </Link>
@@ -60,7 +60,7 @@ ShallowWrapper {
               "textDecoration": "none",
             }
           }
-          to="/create"
+          to="/new"
         >
           Create an Event
         </Link>,
@@ -83,7 +83,7 @@ ShallowWrapper {
             },
             "textDecoration": "none",
           },
-          "to": "/create",
+          "to": "/new",
         },
         "ref": null,
         "rendered": "Create an Event",
@@ -117,7 +117,7 @@ ShallowWrapper {
                 "textDecoration": "none",
               }
             }
-            to="/create"
+            to="/new"
           >
             Create an Event
           </Link>
@@ -143,7 +143,7 @@ ShallowWrapper {
                 "textDecoration": "none",
               }
             }
-            to="/create"
+            to="/new"
           >
             Create an Event
           </Link>,
@@ -166,7 +166,7 @@ ShallowWrapper {
               },
               "textDecoration": "none",
             },
-            "to": "/create",
+            "to": "/new",
           },
           "ref": null,
           "rendered": "Create an Event",

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -1,10 +1,21 @@
+import Radium from 'radium';
 import React from 'react';
-import EventForm from 'components/EventForm'
+import { BrowserRouter as Router, Route } from 'react-router-dom';
+import colors from 'modules/colors';
+import EventForm from 'components/EventForm';
+import Home from 'components/Home';
 
-export default class App extends React.Component {
+class App extends React.Component {
   render() {
     return (
-      <EventForm />
+      <Router>
+        <div>
+          <Route exact path="/" component={Home} />
+          <Route path="/create" component={EventForm} />
+        </div>
+      </Router>
     );
   }
 }
+
+export default Radium(App);

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -11,7 +11,7 @@ class App extends React.Component {
       <Router>
         <div>
           <Route exact path="/" component={Home} />
-          <Route path="/create" component={EventForm} />
+          <Route path="/new" component={EventForm} />
         </div>
       </Router>
     );

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -9,7 +9,7 @@ class Home extends React.Component {
     return (
       <ul style={styles.base}>
         <li style={styles.li}>
-          <StyledLink to="/create" style={styles.a}>Create an Event</StyledLink>
+          <StyledLink to="/new" style={styles.a}>Create an Event</StyledLink>
         </li>
       </ul>
     );

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -1,15 +1,15 @@
 import Radium from 'radium';
 import React from 'react';
+import { Link } from 'react-router-dom';
 
-let Link = require('react-router-dom').Link;
-Link = Radium(Link);
+const StyledLink = Radium(Link);
 
 class Home extends React.Component {
   render() {
     return (
       <ul style={styles.base}>
         <li style={styles.li}>
-          <Link to="/create" style={styles.a}>Create an Event</Link>
+          <StyledLink to="/create" style={styles.a}>Create an Event</StyledLink>
         </li>
       </ul>
     );
@@ -29,8 +29,8 @@ const styles = {
     textDecoration: 'none',
     ':hover': {
       textDecoration: 'underline',
-    }
-  }
+    },
+  },
 }
 
 export default Radium(Home);

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -1,0 +1,36 @@
+import Radium from 'radium';
+import React from 'react';
+
+let Link = require('react-router-dom').Link;
+Link = Radium(Link);
+
+class Home extends React.Component {
+  render() {
+    return (
+      <ul style={styles.base}>
+        <li style={styles.li}>
+          <Link to="/create" style={styles.a}>Create an Event</Link>
+        </li>
+      </ul>
+    );
+  }
+}
+
+const styles = {
+  base: {
+    font: '20px Helvetica, sans-serif',
+  },
+
+  li: {
+    listStyle: 'none',
+  },
+
+  a: {
+    textDecoration: 'none',
+    ':hover': {
+      textDecoration: 'underline',
+    }
+  }
+}
+
+export default Radium(Home);


### PR DESCRIPTION
This PR creates a `Home` component, which contains a `Link` component from `react-router-dom`. Currently there is just one `Link` to the `EventForm`.

`Route` components have been added to `App`, to match routes that will render the `Home` and `EventForm` components.

Note: Since Radium does not work with the `style` prop of non-DOM elements like `Link`, I used a workaround where we assigned a variable to `require('react-router-dom').Link`, and then wrapped that value in a `Radium` component. See https://github.com/FormidableLabs/radium/tree/master/docs/faq#why-doesnt-radium-work-on-react-routers-link-or-react-bootstraps-button-or-someothercomponent

![out](https://user-images.githubusercontent.com/9409378/45534954-a4fdf000-b7b1-11e8-9db9-a72774c7cc9b.gif)
