### PR TITLE
Configure webpack to fall back to historyApi for routing

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,6 +23,7 @@ module.exports = () => {
     output: {
       path: DIST_DIR,
       filename: '[name].js',
+      publicPath: '/',
     },
     module: {
       rules: [
@@ -57,6 +58,7 @@ module.exports = () => {
       publicPath: '/dist/',
       port: 9000,
       hotOnly: true,
+      historyApiFallback: true,
     },
   };
 };


### PR DESCRIPTION
This PR makes a minor change to the webpack config to enable serving of index.html in place of `404` responses when working with the history API.

See the following for details:
https://webpack.js.org/configuration/dev-server/#devserver-historyapifallback
https://stackoverflow.com/questions/44805562/how-to-configure-webpack-dev-server-with-react-router-dom-v4